### PR TITLE
Feature/NEON-2552 caching and push invalidation

### DIFF
--- a/.agents/skills/frontend-cache-management/SKILL.md
+++ b/.agents/skills/frontend-cache-management/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: frontend-cache-management
+description: "Manage the Next.js data cache for Neon CMS pages. Use when adding cache invalidation logic, extending cache tag coverage, debugging stale content, or understanding how the Neon backend should call /api/cache. Triggers: 'cache invalidation', 'revalidate cache', 'stale content', 'cache tags', 'purge cache', 'evict cache', 'cache management'."
+argument-hint: "Describe what changed: 'article not updating', 'need to invalidate a new content type', 'add cache tags for X', etc."
+---
+
+# Frontend Cache Management
+
+This project uses **Next.js 16 `'use cache'` + `cacheTag()`** to cache CMS page responses
+server-side and purge them on demand when Neon publishes content.
+
+---
+
+## Architecture Overview
+
+```
+Neon CMS publishes article / page
+        │
+        ▼
+POST /api/cache   ← guarded by INVALIDATE_NEXTJS_HEADER_NAME / INVALIDATE_NEXTJS_HEADER_VALUE
+        │
+        ▼
+revalidateTag(`neon:node:<id>`, 'default')   ← for each id in evict.ids / revalidate.ids
+revalidatePath(<path>)                        ← for each path in evict.paths / revalidate.paths
+        │
+        ▼
+Next.js purges all 'use cache' entries that were tagged with neon:node:<id>
+        │
+        ├─▶ Article page (tagged neon:node:<ownId>)              → re-fetched on next request
+        └─▶ Webpage / section that listed the article in a zone  → re-fetched on next request
+```
+
+---
+
+## Key Files
+
+| File | Role |
+|---|---|
+| `src/app/api/cache/route.ts` | POST endpoint — validates the secret, validates site name, calls `revalidateTag` / `revalidatePath`; logs every invalidation request |
+| `src/utilities/pageCache.ts` | `fetchPageDataCached()` (LIVE) and `fetchPageDataDirect()` (preview) — cache server function applies tags after parsing |
+| `src/app/[[...slug]]/page.tsx` | Calls `fetchPageDataCached` for `viewStatus === 'live'`; `fetchPageDataDirect` for all other view statuses |
+| `src/lib/logger.ts` | Shared pino logger instance (`name: 'neon-fo'`); each module creates its own child logger |
+
+---
+
+## Cache Tag Convention
+
+Tags are applied inside `fetchPageDataCached()` **after** the JSON is parsed, so they can
+be derived from the actual response data:
+
+| Tag | Applied to | Meaning |
+|---|---|---|
+| `neon:site:<siteName>` | Every live page | Bulk-invalidate the entire site |
+| `neon:node:<nodeId>` | Every live page | The page's **own** CMS node ID — `data.model.data.id` (applies to articles, webpages, sections, liveblogs, etc.) |
+| `neon:node:<targetId>` | Webpage pages | Every article node ID linked in any zone slot (`data.model.data.links.pagelink.*[].targetId`) |
+| `neon:node:<childId>` | Section / list pages | Every child node ID (`data.model.data.children[]`) |
+
+> **Verified**: a webpage cache entry carries the webpage's own `neon:node:<pageId>` tag
+> **plus** one `neon:node:<articleId>` tag for every article that appears in its zones.
+> Evicting a single article ID therefore purges both the article page and every webpage
+> that holds that article in a zone — the full invalidation loop is closed in one call.
+
+### viewStatus Gating
+
+`fetchPageDataCached` is called **only when `viewStatus === 'live'`**. Editorial / preview
+requests (any other `viewStatus`) go through `fetchPageDataDirect`, which always fetches
+fresh from Neon with `cache: 'no-store'` and never writes to the Next.js data cache.
+This ensures editors never see stale cached content.
+
+### Logging
+
+Every cache-build event is logged by the `neon-fo:page-cache` pino child logger:
+
+```json
+{
+  "event": "page-cache-built",
+  "url": "https://api.neon.example/v1/...",
+  "siteName": "adn",
+  "nodeId": "abc123",
+  "baseType": "webpage",
+  "taggedIds": ["abc123", "def456", "ghi789"],
+  "zoneContents": [
+    { "id": "def456", "title": "Article A", "zone": "main" },
+    { "id": "ghi789", "title": "Article B", "zone": "context" }
+  ]
+}
+```
+
+For article / section pages without zones, `zoneContents` is omitted and only `taggedIds`
+(containing just the page's own node ID) is logged.
+
+Every invalidation call to `POST /api/cache` is logged by `neon-fo:cache-api`:
+```json
+{
+  "event": "cache-invalidation-received",
+  "siteName": "adn",
+  "evictIds": ["abc123"],
+  "evictPaths": ["/news/my-article/"],
+  "revalidateIds": [],
+  "revalidatePaths": []
+}
+```
+
+---
+
+## Invalidation Endpoint Contract
+
+**`POST /api/cache`**
+
+### Security
+
+The endpoint returns **404** (not 401) for any auth failure to avoid revealing its existence.
+Two env vars control the guard:
+
+```
+INVALIDATE_NEXTJS_HEADER_NAME=<header-name>      # default: invalidate-secret
+INVALIDATE_NEXTJS_HEADER_VALUE=<secret-value>
+```
+
+The request must include a header matching exactly:
+```
+<INVALIDATE_NEXTJS_HEADER_NAME>: <INVALIDATE_NEXTJS_HEADER_VALUE>
+```
+
+### Request Body
+
+```json
+{
+  "siteName": "my-site-slug",
+  "evict": {
+    "ids":   ["<nodeId1>", "<nodeId2>"],
+    "paths": ["/news/my-article/"]
+  },
+  "revalidate": {
+    "ids":   ["<nodeId3>"],
+    "paths": ["/"]
+  }
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `siteName` | `string` | **Required.** Must match a known site's `root.name`. Returns 400 if unknown. |
+| `evict.ids` | `string[]` | Raw CMS node IDs. The route prefixes each as `neon:node:<id>` before calling `revalidateTag`. |
+| `evict.paths` | `string[]` | URL paths passed directly to `revalidatePath`. |
+| `revalidate.ids` | `string[]` | Same as `evict.ids` — treated identically in the current implementation. |
+| `revalidate.paths` | `string[]` | Same as `evict.paths`. |
+
+> **Note on `ids`**: The caller (Neon CMS backend) sends plain node IDs (e.g. `"abc123"`).
+> The `neon:node:` prefix is applied by the route, not by the caller.
+
+### Response
+
+**200 — success**
+```json
+{
+  "success": true,
+  "message": "Cache instructions processed successfully.",
+  "summary": {
+    "evictedTags": 2,
+    "evictedPaths": 1,
+    "revalidatedTags": 0,
+    "revalidatedPaths": 0
+  }
+}
+```
+
+**400** — unknown `siteName` or unparseable body  
+**404** — missing or wrong secret header  
+**500** — site list lookup or processing error
+
+---
+
+## Cache Lifetime
+
+Live content is cached with the `'hours'` profile (1-hour revalidation window).
+Editorial / preview requests (`auth.editorialAuth` present) use a 5-second TTL so editors
+always see fresh content.
+
+These profiles are set inside `fetchPageDataCached()` via `cacheLife()`.
+
+---
+
+## How to Extend Cache Tag Coverage
+
+If a new content type introduces a new relationship (e.g., an author node linked via
+`links.author[0].targetId`), add its tagging inside `fetchPageDataCached()`:
+
+```ts
+// src/utilities/pageCache.ts  — inside fetchPageDataCached(), after the existing tag blocks
+
+const authorId: string | undefined = data?.model?.data?.links?.author?.[0]?.targetId;
+if (authorId) {
+  cacheTag(`neon:node:${authorId}`);
+}
+```
+
+Then the Neon backend can evict by that author's node ID whenever the author profile changes.
+
+---
+
+## How to Invalidate the Whole Site
+
+Send an eviction for the site tag (currently only supported via `evict.ids` for node-level
+purges, but can be extended). Alternatively, invalidate by path:
+
+```json
+{
+  "siteName": "my-site-slug",
+  "evict": { "paths": ["/"] }
+}
+```
+
+Using `revalidatePath('/', 'layout')` in route code would purge all pages under `/`.
+
+---
+
+## Debugging Stale Content
+
+1. Check that `INVALIDATE_NEXTJS_HEADER_NAME` and `INVALIDATE_NEXTJS_HEADER_VALUE` are set
+   in the deployment environment.
+2. Verify the Neon backend is sending the correct `siteName` (must match `site.root.name`).
+3. Confirm the article's `model.data.id` is included in `evict.ids` — this is the CMS node ID,
+   not the URL slug.
+4. For webpages not updating after an article change: verify the article appears in
+   `model.data.links.pagelink.*` in the webpage's response payload. If the relationship is
+   managed differently (e.g., a separate aggregator call), add the appropriate `cacheTag()`
+   in `fetchPageDataCached()`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,3 +118,49 @@ The local SDK is aliased as a package. Import types and the connection facade li
 import { NeonConnection, PageData, Site } from '@eidosmedia/neon-frontoffice-ts-sdk';
 // connection is a global — no import needed in API routes and server components
 ```
+
+## Cache Invalidation
+
+Pages are cached server-side using Next.js 16 `'use cache'` with demand invalidation via
+`revalidateTag`. The entry point for the Neon CMS backend is:
+
+**`POST /api/cache`** → `src/app/api/cache/route.ts`
+
+Security: the request must include a header whose name and value match env vars
+`INVALIDATE_NEXTJS_HEADER_NAME` and `INVALIDATE_NEXTJS_HEADER_VALUE`. Missing or wrong
+header returns **404**.
+
+Request body shape:
+```json
+{
+  "siteName": "<site root.name>",
+  "evict":      { "ids": ["<nodeId>"], "paths": ["/news/slug/"] },
+  "revalidate": { "ids": ["<nodeId>"], "paths": ["/"] }
+}
+```
+
+- **`ids`** — raw CMS node IDs (no prefix). The route applies the `neon:node:` prefix
+  internally before calling `revalidateTag`.
+- **`paths`** — URL paths forwarded directly to `revalidatePath`.
+- **`siteName`** is validated against `connection.getSitesList()` — unknown names return 400.
+
+Cache tagging is applied in `src/utilities/pageCache.ts` (`fetchPageDataCached`):
+
+| Tag                    | Covers                                                                         |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| `neon:site:<siteName>` | All pages on the site                                                          |
+| `neon:node:<nodeId>`   | The page's own CMS node (`data.model.data.id`) — applies to every content type |
+| `neon:node:<targetId>` | Every article linked in a webpage zone (`data.model.data.links.pagelink.*`)    |
+| `neon:node:<childId>`  | Every child node in a section/list page (`data.model.data.children`)           |
+
+This means evicting one article's `nodeId` purges both the article page **and** every
+listing page that references it in a zone — the full invalidation loop is closed.
+
+**viewStatus gating**: `fetchPageDataCached` is only called when `viewStatus === 'live'`.
+Preview and editorial requests use `fetchPageDataDirect` (always fresh, never cached).
+
+**Logging**: Every cache build (`neon-fo:page-cache`) and every invalidation call
+(`neon-fo:cache-api`) emit structured pino JSON logs with node IDs, zone contents, and paths.
+
+For full details, debugging steps, and how to extend tag coverage to new content types,
+see the **`frontend-cache-management`** skill.

--- a/VERCEL_DEPLOY_STEPS.md
+++ b/VERCEL_DEPLOY_STEPS.md
@@ -1,0 +1,496 @@
+# Vercel Deployment Readiness — Neon CMS Front-Office
+
+## 1. Project Stack Detected
+
+| Layer | Technology | Version |
+|---|---|---|
+| Framework | Next.js (App Router) | ^16.2.6 |
+| Runtime | React | ^19.0.0 |
+| Language | TypeScript | ^5 |
+| Styling | Tailwind CSS | ^4.0.11 |
+| State | Redux Toolkit + React Query | RTK ^2.6.1 / RQ ^5.80.7 |
+| Caching | Next.js `'use cache'` + `revalidateTag` | demand ISR |
+| Auth | httpOnly cookies (`webauth`, `editorialauth`) | server-side only |
+| CMS | Neon CMS via local SDK (`src/neon-frontoffice-ts-sdk`) | local path alias |
+
+ISR is implemented via the `'use cache'` directive in `src/utilities/pageCache.ts`
+(`cacheLife('hours')` + demand invalidation through `POST /api/cache`).
+On Vercel this maps directly to the **Vercel Data Cache**, which is exactly the right
+mechanism for this pattern.
+
+---
+
+## 2. Findings
+
+### 🔴 BLOCKER — `src/proxy.ts` is not wired as Next.js middleware
+
+**File:** `src/proxy.ts`
+
+The file contains all the critical request-routing logic:
+- resolving the Neon site from the incoming host via `x-forwarded-host`
+- injecting `x-neon-backend-url`, `x-neon-site-name`, `x-neon-view-status`,
+  `x-neon-pathname` headers that every page component depends on
+- handling the `?PreviewToken=…` flow (calls `connection.previewAuthorization()`,
+  sets the `editorialauth` httpOnly cookie)
+- handling the `?switch-view=preview|live` flow
+- rewriting `/resources/…` and `/nodes/…` to internal API routes
+
+**The problem:** Next.js only picks up a file named `middleware.ts` (or `middleware.js`)
+placed at `src/middleware.ts`. The exported function must be named `middleware` (not
+`proxy`). Currently, `src/proxy.ts` exports `proxy` — it is **never executed** by
+Next.js. The `export const config = { matcher: … }` inside `proxy.ts` is also dead code.
+
+**Impact without fix:** Site resolution fails entirely. All pages receive `null` headers,
+making `viewStatus`, `siteName`, `hostname`, and `path` undefined. Authentication
+preview and switch-view flows never run.
+
+**Fix (Step 1 below):** Rename the file to `src/middleware.ts` and rename the exported
+function from `proxy` to `middleware`.
+
+---
+
+### 🔴 BLOCKER — `output: 'standalone'` must be removed for Vercel
+
+**File:** `next.config.ts`
+
+```ts
+output: 'standalone',   // ← REMOVE THIS
+```
+
+`standalone` mode bundles the Node.js server and all dependencies into a
+`.next/standalone` directory, designed for Docker / self-hosted deployments. Vercel
+builds its own output format and ignores this field, which can cause silent build
+failures or unexpected artefacts. Remove it entirely; Vercel will build correctly
+without it.
+
+---
+
+### 🔴 BLOCKER — `setInterval` for sites refresh will not survive Vercel serverless
+
+**File:** `src/instrumentation.ts`
+
+```ts
+setInterval(() => {
+  connection.refreshLiveSites();
+  connection.refreshPreviewSites();
+}, parseInt(process.env.SITES_REFRESH_INTERVAL || '') || 120000);
+```
+
+Vercel functions are stateless: each function instance is spun up on demand and
+torn down after a period of inactivity. A `setInterval` registered on cold start
+will fire while the instance is warm, but it will never fire across cold starts.
+If a cold start happens after a long idle period, `connection` holds stale sites
+data until the next interval tick, which might never come before the function
+is torn down again.
+
+**Fix (Step 2 below):** Replace the interval with a lightweight TTL guard called
+from the middleware on each request. This ensures sites are refreshed at most
+once every `SITES_REFRESH_INTERVAL` ms regardless of function lifecycle.
+
+---
+
+### 🟠 IMPORTANT — `NODE_TLS_REJECT_UNAUTHORIZED=0` must not reach Vercel
+
+**File:** `.env` (local only)
+
+The local `.env` file contains:
+
+```
+NODE_TLS_REJECT_UNAUTHORIZED=0
+```
+
+This disables TLS certificate validation entirely. It is needed locally only
+because the dev Neon backend (`*.neon.test`) uses a self-signed certificate.
+On Vercel, the Neon CMS production backend must have a valid TLS certificate,
+and this variable must **not** be set in the Vercel project environment.
+
+`.env` is typically committed; confirm `.gitignore` excludes it or rotate
+secrets if this file is tracked. **Do not add this variable to the Vercel
+dashboard.**
+
+---
+
+### 🟠 IMPORTANT — `DEV_MODE` must be set to `false` on Vercel
+
+**File:** `src/proxy.ts` (future `src/middleware.ts`)
+
+Cookie security attributes for the `editorialauth` cookie are gated on:
+
+```ts
+sameSite: process.env.DEV_MODE === 'false' ? 'none' : false,
+secure: process.env.DEV_MODE === 'false',
+```
+
+On Vercel (HTTPS), `DEV_MODE=false` must be set so that the `editorialauth`
+cookie is issued with `Secure; SameSite=None`. Without it the cookie is set
+without the `Secure` flag, which is required for cross-site editorial flows when
+the CMS editor (on a different domain) triggers preview navigation.
+
+---
+
+### 🟠 IMPORTANT — All required environment variables must be declared in Vercel
+
+The project reads the following environment variables at runtime. All must be
+configured in the Vercel project settings under **Settings → Environment Variables**:
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `BASE_NEON_FO_URL` | ✅ yes | Neon front-office backend base URL |
+| `NEON_FRONTOFFICE_SERVICE_KEY` | ✅ yes | Service key sent to Neon CMS for authenticated SDK calls |
+| `NEON_APP_URL` | ✅ yes | URL of the Neon editorial app (used for "Edit" deep-link in `LoggedUserBar`) |
+| `INVALIDATE_NEXTJS_HEADER_NAME` | ✅ yes | Name of the secret header that guards `POST /api/cache` |
+| `INVALIDATE_NEXTJS_HEADER_VALUE` | ✅ yes | Value of the secret header — treat as a strong random token |
+| `DEV_MODE` | ✅ yes | Set to `false` in all Vercel environments (Production, Preview, Development) |
+| `DEV_FORCE_SITE` | ❌ no | **Leave unset on Vercel.** Used only to override site resolution on localhost |
+| `SITES_REFRESH_INTERVAL` | optional | Override the 120 000 ms sites refresh TTL. Defaults to 120 000 if absent |
+| `NODE_TLS_REJECT_UNAUTHORIZED` | ❌ never | **Never set on Vercel.** Local dev only |
+
+---
+
+### 🟡 MEDIUM — Verify `'use cache'` is active without `experimental.dynamicIO`
+
+**File:** `src/utilities/pageCache.ts`, `next.config.ts`
+
+The project uses the `'use cache'` directive with `cacheTag` and `cacheLife`
+(both imported from `next/cache`). In Next.js 15.0–15.1 this required
+`experimental: { dynamicIO: true }`. As of Next.js 15.2 it became stable.
+The project is on `^16.2.6`, so no experimental flag is needed.
+
+**Action:** Run `next build` locally once and confirm there are no warnings about
+`'use cache'` requiring an experimental flag. If warnings appear, add:
+
+```ts
+// next.config.ts
+experimental: {
+  dynamicIO: true,
+},
+```
+
+On Vercel, `'use cache'` with `revalidateTag` maps to the Vercel Data Cache.
+The `/api/cache` invalidation endpoint (`revalidateTag` + `revalidatePath`) will
+work exactly as in local builds — this is the fully supported ISR path on Vercel.
+
+---
+
+### 🟡 MEDIUM — Neon CMS backend must allow requests from Vercel's IP ranges
+
+The middleware resolves the site by calling `connection.resolveApiHostname(url)`
+with the incoming `x-forwarded-host`. In production on Vercel, the origin IP of
+each serverless invocation comes from Vercel's AWS Lambda pool.
+
+If the Neon back-office has an IP allowlist for the front-office service key,
+Vercel's dynamic IPs will not match. Solution: either remove the IP restriction
+for the service key, or configure the allowlist to accept the Vercel CIDR ranges
+(documented at `https://vercel.com/docs/security/deployment-protection/methods-to-protect-deployments/vercel-firewall`).
+
+---
+
+### 🟡 MEDIUM — `require('../../../../package.json')` in `/api/health`
+
+**File:** `src/app/api/health/route.ts`
+
+```ts
+const packageJson = require('../../../../package.json');
+```
+
+This CommonJS `require` works in Next.js Node.js runtime routes. It will NOT
+work if the route is ever switched to the Edge Runtime. Keep the route as
+Node.js (no `export const runtime = 'edge'`). No action needed unless you
+want to move it to Edge.
+
+---
+
+### 🟢 LOW — `allowedDevOrigins` is dev-only, no action needed
+
+`allowedDevOrigins: ['*.neon.test']` in `next.config.ts` only applies to the
+dev server (CORS for WebSocket HMR). Safe to leave in — Vercel ignores it.
+
+---
+
+### 🟢 LOW — `trailingSlash: true` works on Vercel with no changes
+
+Vercel honours `trailingSlash: true` natively. No action required.
+
+---
+
+### 🟢 LOW — Local SDK install step is not needed on Vercel
+
+`package.json` has a helper script:
+```
+"ci-frontoffice": "npm ci --prefix ./src/neon-frontoffice-ts-sdk"
+```
+
+The local SDK (`src/neon-frontoffice-ts-sdk`) has **only** dev dependencies
+(jest, typescript, eslint). The Next.js build compiles the SDK source directly
+via the TypeScript path alias `@eidosmedia/neon-frontoffice-ts-sdk →
+./src/neon-frontoffice-ts-sdk/src`. No separate install is needed on Vercel;
+the root `npm install` is sufficient.
+
+---
+
+### 🟢 LOW — `certificates/` directory is for local HTTPS dev only
+
+The `certificates/` directory contains self-signed certificates used by
+`next dev --experimental-https`. Vercel manages TLS automatically; this
+directory has no effect on the Vercel build or runtime.
+
+---
+
+## 3. Implementation Plan
+
+### Step 1 — Fix the middleware (BLOCKER)
+
+Rename `src/proxy.ts` → `src/middleware.ts` and rename the exported function.
+No logic changes are needed — only the filename and function name matter to Next.js.
+
+**`src/middleware.ts`** (was `src/proxy.ts`):
+
+```diff
+- export async function proxy(request: NextRequest) {
++ export async function middleware(request: NextRequest) {
+```
+
+All other code in the file stays identical. Verify the bottom of the file still
+exports the matcher:
+
+```ts
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image).*)'],
+};
+```
+
+> After this rename, delete `src/proxy.ts`.
+
+---
+
+### Step 2 — Replace `setInterval` with a per-request TTL refresh (BLOCKER)
+
+In `src/instrumentation.ts`, replace the `setInterval` block with a module-level
+TTL variable and a callable function that the middleware will invoke:
+
+```ts
+// src/instrumentation.ts  (replace only the interval section)
+
+let _lastSitesRefresh = 0;
+
+export function maybeRefreshSites(): void {
+  const interval = parseInt(process.env.SITES_REFRESH_INTERVAL || '') || 120_000;
+  const now = Date.now();
+  if (now - _lastSitesRefresh >= interval) {
+    _lastSitesRefresh = now;
+    connection.refreshLiveSites();
+    connection.refreshPreviewSites();
+  }
+}
+
+// Remove the setInterval block entirely.
+```
+
+In `src/middleware.ts` (after Step 1), call it at the top of `middleware()`:
+
+```ts
+import { maybeRefreshSites } from './instrumentation';
+
+export async function middleware(request: NextRequest) {
+  maybeRefreshSites();   // ← add this line
+  // ... rest of function unchanged
+```
+
+This keeps the refresh frequency identical to the current behaviour, but works
+correctly in both serverless (each warm request checks the TTL) and long-running
+(interval-equivalent) environments.
+
+---
+
+### Step 3 — Remove `output: 'standalone'` from `next.config.ts` (BLOCKER)
+
+```diff
+ const nextConfig: NextConfig = {
+-  output: 'standalone',
+   trailingSlash: true,
+   allowedDevOrigins: ['*.neon.test'],
+ };
+```
+
+---
+
+### Step 4 — Add `vercel.json` with Neon CMS cache-invalidation passthrough
+
+Create a `vercel.json` at the project root. The main purpose is to ensure the
+`POST /api/cache` webhook from Neon CMS is never rate-limited and to configure
+the function timeout to allow cache operations to complete:
+
+```json
+{
+  "functions": {
+    "src/app/api/cache/route.ts": {
+      "maxDuration": 30
+    }
+  }
+}
+```
+
+If you want to use Vercel Cron Jobs as an additional safety net for sites refresh
+(so cold starts after long idle periods also pick up new sites), add:
+
+```json
+{
+  "crons": [
+    {
+      "path": "/api/health",
+      "schedule": "*/5 * * * *"
+    }
+  ],
+  "functions": {
+    "src/app/api/cache/route.ts": {
+      "maxDuration": 30
+    }
+  }
+}
+```
+
+This pings `/api/health` every 5 minutes; the warm request running `maybeRefreshSites()`
+in the middleware keeps sites data current. The health endpoint also calls
+`connection.getBackendInfo()`, which validates the CMS connection is alive.
+
+> Note: Vercel Cron Jobs are only available on Pro and above plans.
+
+---
+
+### Step 5 — Set environment variables in Vercel
+
+Go to **Vercel Dashboard → Project → Settings → Environment Variables** and add:
+
+| Variable | Production | Preview | Development |
+|---|---|---|---|
+| `BASE_NEON_FO_URL` | Neon prod FO URL | Neon staging FO URL | (use `.env.local`) |
+| `NEON_FRONTOFFICE_SERVICE_KEY` | prod key | staging key | (use `.env.local`) |
+| `NEON_APP_URL` | Neon prod app URL | Neon staging app URL | (use `.env.local`) |
+| `INVALIDATE_NEXTJS_HEADER_NAME` | strong header name | same | same |
+| `INVALIDATE_NEXTJS_HEADER_VALUE` | strong random token | different token | (use `.env.local`) |
+| `DEV_MODE` | `false` | `false` | `false` |
+| `NODE_TLS_REJECT_UNAUTHORIZED` | **DO NOT SET** | **DO NOT SET** | **DO NOT SET** |
+
+Keep `DEV_FORCE_SITE` out of Vercel entirely — leave it only in your local `.env`.
+
+---
+
+### Step 6 — Verify `'use cache'` and build locally before pushing
+
+```bash
+npm run build
+```
+
+Confirm:
+- No warnings about `'use cache'` or `dynamicIO`
+- The `src/middleware.ts` file is detected (Next.js prints `✓ Middleware`)
+- All routes compile without error
+
+If `'use cache'` warnings appear, add to `next.config.ts`:
+
+```ts
+experimental: {
+  dynamicIO: true,
+},
+```
+
+---
+
+### Step 7 — Configure Vercel project settings
+
+In **Vercel Dashboard → Project → Settings → General**:
+
+| Setting | Value |
+|---|---|
+| Framework Preset | Next.js (auto-detected) |
+| Build Command | `npm run build` (default) |
+| Install Command | `npm install` (default — do NOT add `ci-frontoffice`) |
+| Output Directory | (leave as default — `.next`) |
+| Node.js Version | 20.x or 22.x (match your local Node) |
+
+---
+
+### Step 8 — Configure Neon CMS to call the Vercel cache endpoint
+
+In Neon CMS back-office, configure the front-office cache invalidation webhook to
+call:
+
+```
+POST https://<your-vercel-domain>/api/cache
+<INVALIDATE_NEXTJS_HEADER_NAME>: <INVALIDATE_NEXTJS_HEADER_VALUE>
+Content-Type: application/json
+```
+
+Body format (unchanged from the current spec in `AGENTS.md`):
+```json
+{
+  "siteName": "<site root.name>",
+  "evict":      { "ids": ["<nodeId>"], "paths": ["/news/slug/"] },
+  "revalidate": { "ids": ["<nodeId>"], "paths": ["/"] }
+}
+```
+
+---
+
+## 4. ISR Architecture on Vercel (no changes needed to logic)
+
+```
+Neon CMS backend
+  └─ publishes article
+      └─ POST /api/cache  (Vercel deployment)
+          ├─ revalidateTag('neon:node:<articleId>')
+          │     purges: article page + all listing pages that zone it
+          └─ revalidatePath('/news/slug/')
+
+Visitor request
+  └─ middleware.ts  (Edge Network)
+      ├─ maybeRefreshSites()         ← new: replaces setInterval
+      ├─ resolves site from x-forwarded-host
+      └─ injects x-neon-* headers
+          └─ [[...slug]]/page.tsx    (Node.js Lambda)
+              ├─ viewStatus === 'live'  → fetchPageDataCached()
+              │     'use cache' → Vercel Data Cache (ISR)
+              │     cacheLife('hours') + cacheTag('neon:node:...')
+              └─ viewStatus !== 'live' → fetchPageDataDirect()  (no cache)
+```
+
+---
+
+## 5. Preview & Auth flows — no changes needed to logic, middleware fix unlocks them
+
+### Preview token flow (Neon CMS editor → front-office)
+1. Editor clicks "Preview" in Neon App
+2. Browser navigates to `https://<site>/<path>?PreviewToken=…&id=…&siteName=…`
+3. **`middleware.ts`** (after fix) calls `connection.previewAuthorization()`
+4. Sets `editorialauth` httpOnly cookie with `Secure; SameSite=None` (when `DEV_MODE=false`)
+5. Rewrites to clean URL → page renders via `fetchPageDataDirect` (no ISR)
+
+### Switch-view flow
+1. Editorial toolbar sends `?switch-view=preview&switch-token=<cookie-value>`
+2. **`middleware.ts`** sets `editorialauth` cookie and redirects to clean URL
+3. All subsequent requests carry the cookie; `viewStatus` is resolved as `PREVIEW`
+
+### Reader auth flow
+1. Reader logs in via `/login` → `POST /api/users/login`
+2. Server sets `webauth` httpOnly cookie
+3. `getAuthOptions()` reads both cookies on every page render and API call
+4. `useAuth` hook (`/api/users` via React Query) keeps the client state in sync
+
+All three flows depend on the middleware being active. **Step 1 unblocks all of them.**
+
+---
+
+## 6. Summary Checklist
+
+| # | Action | Priority | File(s) |
+|---|---|---|---|
+| 1 | Rename `proxy.ts` → `middleware.ts`, rename `proxy` fn → `middleware` | 🔴 BLOCKER | `src/proxy.ts` → `src/middleware.ts` |
+| 2 | Replace `setInterval` with `maybeRefreshSites()` + call from middleware | 🔴 BLOCKER | `src/instrumentation.ts`, `src/middleware.ts` |
+| 3 | Remove `output: 'standalone'` from `next.config.ts` | 🔴 BLOCKER | `next.config.ts` |
+| 4 | Add `vercel.json` with `maxDuration` for `/api/cache` | 🟠 IMPORTANT | `vercel.json` (new) |
+| 5 | Set env vars in Vercel dashboard (especially `DEV_MODE=false`) | 🟠 IMPORTANT | Vercel dashboard |
+| 6 | Ensure `NODE_TLS_REJECT_UNAUTHORIZED=0` is NOT set on Vercel | 🟠 IMPORTANT | Vercel dashboard |
+| 7 | Configure Neon CMS webhook to POST to `/api/cache` on Vercel URL | 🟠 IMPORTANT | Neon CMS config |
+| 8 | Run `npm run build` locally and verify no `'use cache'` warnings | 🟡 MEDIUM | — |
+| 9 | Confirm Neon backend TLS cert is valid (no self-signed in prod) | 🟡 MEDIUM | Neon CMS infra |
+| 10 | Verify Neon backend does not IP-allowlist the front-office service key | 🟡 MEDIUM | Neon CMS config |

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,7 @@ const nextConfig: NextConfig = {
   output: 'standalone',
   trailingSlash: true,
   allowedDevOrigins: ['*.neon.test'],
+  cacheComponents: true,
 };
 
 export default nextConfig;

--- a/src/app/[[...slug]]/page.tsx
+++ b/src/app/[[...slug]]/page.tsx
@@ -6,6 +6,7 @@ import type { Metadata } from 'next';
 import { getAuthOptions } from '@/utilities/security';
 import UIStyleGuide from '../components/baseComponents/UIStyleGuide';
 import * as DefaultPages from '../_pages';
+import { fetchPageDataCached, fetchPageDataDirect, type CachedPageResult } from '@/utilities/pageCache';
 
 export default async function Page({
   params,
@@ -80,40 +81,36 @@ export default async function Page({
   const auth = await getAuthOptions();
   const url = resolveUrl(hostname, path, id as string);
 
-  let pageData;
+  let result: CachedPageResult | undefined;
 
   try {
-    pageData = await connection.makePageRequest(url, auth, {
-      redirect: 'manual',
-      cache: 'no-cache',
-    });
+    result =
+      viewStatus === 'live'
+        ? await fetchPageDataCached(url, siteName ?? '', auth)
+        : await fetchPageDataDirect(url, auth);
   } catch (error: any) {
     if (error.status === 404) {
       notFound();
     }
 
-    // handle 401 and 403 unauthorized
+    // handle 401, 403, and 410 unauthorized / gone
     if (error.status === 401 || error.status === 403 || error.status === 410) {
       notFound();
     }
   }
 
-  if (!pageData) {
+  if (!result) {
     notFound();
   }
 
   // handle redirection
-  if (pageData.status > 300 && pageData.status < 400) {
-    const newLocation = pageData.headers.get('Location') as string;
-    redirect(newLocation);
+  if (result.redirectLocation) {
+    redirect(result.redirectLocation);
   }
 
-  const pageDataJSON = await pageData.json();
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const pageDataJSON = result.data!;
   console.log('Current page model', pageDataJSON);
-
-  if (process.env.NODE_ENV === 'development' && pageData.status >= 500) {
-    throw new Error(pageDataJSON.model.data.trace);
-  }
 
   const siteLive = await connection.findSite(siteName ?? '', 'live');
   const sitePreview = await connection.findSite(siteName ?? '', 'preview');
@@ -128,9 +125,11 @@ export default async function Page({
 
   // For article longform, use a sub-type key so themes can differentiate
   const componentKey =
-    baseType === 'article' && type === 'longform' ? 'ArticleLongform'
-    : baseType === 'webpage' && type === 'newsletter' ? 'NewsletterWebpage'
-    : resolveBaseTypeKey(baseType);
+    baseType === 'article' && type === 'longform'
+      ? 'ArticleLongform'
+      : baseType === 'webpage' && type === 'newsletter'
+        ? 'NewsletterWebpage'
+        : resolveBaseTypeKey(baseType);
   const PageComponent = resolvePageComponent(componentKey, theme);
 
   return (
@@ -141,11 +140,7 @@ export default async function Page({
           editUrl: `${process.env.NEON_APP_URL}/neon/app/neon.html#open/${pageDataJSON.model.data.id}`,
         }}
       />
-      {PageComponent ? (
-        <PageComponent data={pageDataJSON} />
-      ) : (
-        <DefaultPages.Article data={pageDataJSON} />
-      )}
+      {PageComponent ? <PageComponent data={pageDataJSON} /> : <DefaultPages.Article data={pageDataJSON} />}
     </div>
   );
 }
@@ -178,6 +173,8 @@ export async function generateMetadata({
   const currentHeaders = await headers();
 
   const hostname = currentHeaders.get('x-neon-backend-url');
+  const siteName = currentHeaders.get('x-neon-site-name') ?? '';
+  const viewStatus = currentHeaders.get('x-neon-view-status') as string;
   const path = currentHeaders.get('x-neon-pathname') as string;
   const slug = (await params).slug || [];
   const id = (await searchParams)?.id;
@@ -185,8 +182,6 @@ export async function generateMetadata({
 
   const url = resolveUrl(hostname, path, id as string);
   try {
-    let title;
-
     if (slug && slug.length === 1) {
       switch (slug[0]) {
         case 'search':
@@ -197,28 +192,18 @@ export async function generateMetadata({
           return { title: 'Login' };
       }
     }
-    const pageData = await connection.makePageRequest(url, auth, {
-      redirect: 'manual',
-      cache: 'no-cache',
-    });
 
-    if (pageData.status == 200) {
-      const pageDataJSON = await pageData.json();
+    const result =
+      viewStatus === 'live' ? await fetchPageDataCached(url, siteName, auth) : await fetchPageDataDirect(url, auth);
 
-      if (!title) {
-        title = pageDataJSON.model.data.title;
-      }
-
+    if (result.status === 200 && result.data) {
       return {
-        title: `${pageDataJSON.siteData.siteName} - ${title}`,
-        description: pageDataJSON.model.data.summary,
-      };
-    } else {
-      return {
-        title: 'Error',
-        description: 'Failed to generate metadata.',
+        title: `${result.data.siteData?.siteName} - ${result.data.model?.data?.title}`,
+        description: result.data.model?.data?.summary,
       };
     }
+
+    return { title: 'Error', description: 'Failed to generate metadata.' };
   } catch (error) {
     console.warn('Error generating metadata:', error);
     return {

--- a/src/app/api/cache/route.ts
+++ b/src/app/api/cache/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidateTag, revalidatePath } from 'next/cache';
+import pino from 'pino';
+
+const logger = pino({ name: 'neon-fo:cache-api' });
+
+interface CachePayload {
+  siteName: string;
+  evict?: { ids?: string[]; paths?: string[] };
+  revalidate?: { ids?: string[]; paths?: string[] };
+}
+
+export async function POST(request: NextRequest) {
+  const headerName = process.env.INVALIDATE_NEXTJS_HEADER_NAME ?? 'invalidate-secret';
+  const secret = request.headers.get(headerName);
+  if (!secret || secret !== process.env.INVALIDATE_NEXTJS_HEADER_VALUE) {
+    return NextResponse.json({ error: 'Not Found - Invalid Call'}, { status: 404 });
+  }
+
+  let body: CachePayload;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body.' }, { status: 400 });
+  }
+
+  try {
+    const sites = await connection.getSitesList();
+    const knownSiteNames = sites.map((s) => s.root.name);
+    if (!body.siteName || !knownSiteNames.includes(body.siteName)) {
+      return NextResponse.json({ error: 'Unknown site name.' }, { status: 400 });
+    }
+  } catch {
+    return NextResponse.json({ error: 'Failed to validate site name.' }, { status: 500 });
+  }
+
+  try {
+    const summary = { evictedTags: 0, evictedPaths: 0, revalidatedTags: 0, revalidatedPaths: 0 };
+
+    logger.info(
+      {
+        event: 'cache-invalidation-received',
+        siteName: body.siteName,
+        evictIds: body.evict?.ids ?? [],
+        evictPaths: body.evict?.paths ?? [],
+        revalidateIds: body.revalidate?.ids ?? [],
+        revalidatePaths: body.revalidate?.paths ?? [],
+      },
+      `[cache-api] invalidation for "${body.siteName}" — evict ids: [${(body.evict?.ids ?? []).join(', ')}] paths: [${(body.evict?.paths ?? []).join(', ')}]`,
+    );
+    if (body.evict) {
+      if (body.evict.ids) {
+        body.evict.ids.forEach((id) => revalidateTag(`neon:node:${id}`, 'default'));
+        summary.evictedTags = body.evict.ids.length;
+      }
+      if (body.evict.paths) {
+        body.evict.paths.forEach((path) => revalidatePath(path));
+        summary.evictedPaths = body.evict.paths.length;
+      }
+    }
+
+    if (body.revalidate) {
+      if (body.revalidate.ids) {
+        body.revalidate.ids.forEach((id) => revalidateTag(`neon:node:${id}`, 'default'));
+        summary.revalidatedTags = body.revalidate.ids.length;
+      }
+      if (body.revalidate.paths) {
+        body.revalidate.paths.forEach((path) => revalidatePath(path));
+        summary.revalidatedPaths = body.revalidate.paths.length;
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: 'Cache instructions processed successfully.',
+      summary,
+    }, { status: 200 });
+
+  } catch {
+    return NextResponse.json({ error: 'Processing error.' }, { status: 500 });
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Script from 'next/script';
 import { Inter } from 'next/font/google';
+import { Suspense } from 'react';
 import { WebVitals } from './components/utilities/WebVitals';
 import './globals.css';
 import { ReloadListener } from './components/utilities/ReloadListener';
@@ -81,9 +82,11 @@ export default async function RootLayout({
         <WebVitals />
         <ReactShimExposer />
         <ReloadListener />
-        <StoreProvider>
-          <QueryProvider>{children}</QueryProvider>
-        </StoreProvider>
+        <Suspense fallback={null}>
+          <StoreProvider>
+            <QueryProvider>{children}</QueryProvider>
+          </StoreProvider>
+        </Suspense>
       </body>
     </html>
   );

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,5 @@
+import pino from 'pino';
+
+const logger = pino({ name: 'neon-fo' });
+
+export default logger;

--- a/src/utilities/pageCache.ts
+++ b/src/utilities/pageCache.ts
@@ -1,0 +1,147 @@
+import { cacheTag, cacheLife } from 'next/cache';
+import type { AuthContext } from '@eidosmedia/neon-frontoffice-ts-sdk';
+import pino from 'pino';
+
+const logger = pino({ name: 'neon-fo:page-cache' });
+
+export type CachedPageResult = {
+  status: number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data?: any;
+  redirectLocation?: string;
+};
+
+/**
+ * Non-cached fetch — used for preview / editorial (viewStatus !== 'live').
+ * Never writes to the Next.js data cache.
+ */
+export async function fetchPageDataDirect(
+  url: string,
+  auth: AuthContext,
+): Promise<CachedPageResult> {
+  const response: Response = await connection.makePageRequest(url, auth, {
+    redirect: 'manual',
+    cache: 'no-store',
+  });
+
+  if (response.status > 300 && response.status < 400) {
+    return {
+      status: response.status,
+      redirectLocation: response.headers.get('Location') ?? '/',
+    };
+  }
+
+  return { status: response.status, data: await response.json() };
+}
+
+/**
+ * Fetches and caches a CMS page response — LIVE content only.
+ *
+ * Cache tags applied:
+ *  - `neon:site:<siteName>`        — all pages for the site (bulk site invalidation)
+ *  - `neon:node:<nodeId>`          — the page's own CMS node (article / webpage / section)
+ *  - `neon:node:<zoneArticleId>`   — every article node ID found in zones (webpage / section pages)
+ *
+ * This closes the invalidation loop: evicting a single article node ID purges both the
+ * article page AND every listing page (webpage / section) that holds it in a zone.
+ */
+export async function fetchPageDataCached(
+  url: string,
+  siteName: string,
+  auth: AuthContext,
+): Promise<CachedPageResult> {
+  'use cache';
+
+  // Live content only — long-lived, demand-invalidated via revalidateTag
+  cacheLife('hours');
+
+  // Inner fetch bypasses the HTTP cache — the outer 'use cache' owns persistence
+  const response: Response = await connection.makePageRequest(url, auth, {
+    redirect: 'manual',
+    cache: 'no-store',
+  });
+
+  // Redirects: return the location without caching page content
+  if (response.status > 300 && response.status < 400) {
+    return {
+      status: response.status,
+      redirectLocation: response.headers.get('Location') ?? '/',
+    };
+  }
+
+  const data = await response.json();
+
+  // ── Cache tags + collection for logging ──────────────────────────────────────
+
+  cacheTag(`neon:site:${siteName}`);
+
+  const nodeId: string | undefined = data?.model?.data?.id;
+  if (nodeId) {
+    cacheTag(`neon:node:${nodeId}`);
+  }
+
+  const taggedIds: string[] = nodeId ? [nodeId] : [];
+
+  type ZoneItem = { id: string; title: string; zone: string };
+  const zoneItems: ZoneItem[] = [];
+
+  // Webpage zones: each linked article in any zone slot
+  const pageLinks = data?.model?.data?.links?.pagelink;
+  if (pageLinks && typeof pageLinks === 'object') {
+    for (const [zoneName, zone] of Object.entries(pageLinks)) {
+      if (Array.isArray(zone)) {
+        for (const link of zone as Array<{ targetId?: string }>) {
+          if (link?.targetId) {
+            cacheTag(`neon:node:${link.targetId}`);
+            taggedIds.push(link.targetId);
+            zoneItems.push({
+              id: link.targetId,
+              title: data?.model?.nodes?.[link.targetId]?.title ?? '(no title)',
+              zone: zoneName,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // Section / list pages: children node IDs
+  const children: unknown = data?.model?.data?.children;
+  if (Array.isArray(children)) {
+    for (const childId of children as string[]) {
+      if (childId) {
+        cacheTag(`neon:node:${childId}`);
+        taggedIds.push(childId);
+      }
+    }
+  }
+
+  // ── Logging ──────────────────────────────────────────────────────────────────
+
+  const baseType: string = data?.model?.data?.sys?.baseType ?? 'unknown';
+  const pageTitle: string = data?.model?.data?.title ?? url;
+
+  if (zoneItems.length > 0) {
+    logger.info(
+      {
+        event: 'page-cache-built',
+        url,
+        siteName,
+        nodeId,
+        baseType,
+        taggedIds,
+        zoneContents: zoneItems,
+      },
+      `[page-cache] built ${baseType} "${pageTitle}" — ${taggedIds.length} tag(s), zone: ${
+        zoneItems.map((z) => `${z.zone}/${z.id} "${z.title}"`).join(', ')
+      }`,
+    );
+  } else {
+    logger.info(
+      { event: 'page-cache-built', url, siteName, nodeId, baseType, taggedIds },
+      `[page-cache] built ${baseType} "${pageTitle}" — ${taggedIds.length} tag(s)`,
+    );
+  }
+
+  return { status: response.status, data };
+}


### PR DESCRIPTION
Add LIVE site caching with tagging of the contents

new API to be used by us to handle the invalidateTag to be called by Neon cache-invalidation service 